### PR TITLE
Update latest-release-version

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -1,8 +1,6 @@
 name: test
 
-on:
-  push:
-    branches: [test_action]
+on: [push, pull_requests]
 
 jobs:
   job-name:

--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  push:
+    branches: [test_action]
+
+jobs:
+  job-name:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Fetch latest release version
+        id: fetch-latest-release
+        uses: ./
+
+      - name: Test
+        run: echo ${{ steps.fetch-latest-release.outputs.latest-release }}

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Fetch latest release version
         id: fetch-latest-release
-        uses: reloc8/action-latest-release-version@1.0.0
+        uses: reloc8/action-latest-release-version@1.0.1
 
       - name: Test
         run: echo ${{ steps.fetch-latest-release.outputs.latest-release }}

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,6 @@ runs:
         git fetch --tags
         git fetch --prune --unshallow || true
         export LATEST_RELEASE_VERSION=$(git describe --abbrev=0 --tags)
-        echo "::set-output name=latest-release::$(echo $LATEST_RELEASE_VERSION)"
+        echo "latest-release=$LATEST_RELEASE_VERSION" >> $GITHUB_OUTPUT
         echo The latest release version is \"$LATEST_RELEASE_VERSION\".
       shell: bash


### PR DESCRIPTION
Updates for:

- New `GITHUB_ENV` command instead of `set-output` (deprecated)
- New version for checkout action v2 -> v3
- New GitHub action to run the action locally
- Version bump